### PR TITLE
RFC3339Nano timestamp (resolves #1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-REGISTRY_NAME?=docker.io/sbezverk
-IMAGE_VERSION?=0.0.0
+REGISTRY_NAME?=docker.io/codebgp
+IMAGE_VERSION?=0.0.1
 
 .PHONY: all gobmp player container push clean test
 

--- a/pkg/bmp/per-peer-header.go
+++ b/pkg/bmp/per-peer-header.go
@@ -119,7 +119,7 @@ func (p *PerPeerHeader) GetPeerTimestamp() string {
 	tms := time.Duration(int(binary.BigEndian.Uint32(p.PeerTimestamp[4:8])))
 	t = t.Add(ts)
 	t = t.Add(tms)
-	return t.Format(time.StampMicro)
+	return t.Format(time.RFC3339Nano)
 }
 
 // GetPeerHash calculates Peer Hash and returns as a hex string


### PR DESCRIPTION
This takes care of the time (year-missing) issue.

Available formats: https://golang.org/src/time/format.go